### PR TITLE
The links provided for lc-tlscert are broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Quick Start
 -----------
 
 First, use the
-[lc-tlscert](https://github.com/driskell/log-courier/blob/develop/src/lc-tlscert/lc-tlscert.go)
+[lc-tlscert](https://github.com/driskell/log-courier/blob/master/src/lc-tlscert/lc-tlscert.go)
 tool to generate self-signed SSL certificates:
 
 ```
-$ wget https://raw.githubusercontent.com/driskell/log-courier/develop/src/lc-tlscert/lc-tlscert.go
+$ wget https://raw.githubusercontent.com/driskell/log-courier/master/src/lc-tlscert/lc-tlscert.go
 $ go run lc-tlscert.go
 ```
 


### PR DESCRIPTION
I'm not sure if those links should point to file on `develop` branch, github returns 404 error. You can find it on `master` branch.
